### PR TITLE
Subject: [PATCH] [Modified]: PLL(rcc): PCLK1 setting issue.

### DIFF
--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -176,13 +176,12 @@ impl CFGR {
         let ppre1_bits = self.pclk1
             .map(|pclk1| match hclk / pclk1 {
                 0 => unreachable!(),
-                1 => 0b011,
                 2 => 0b100,
                 3...5 => 0b101,
                 6...11 => 0b110,
                 _ => 0b111,
             })
-            .unwrap_or(0b011);
+            .unwrap_or(0b100);
 
         let ppre1 = 1 << (ppre1_bits - 0b011);
         let pclk1 = hclk / u32(ppre1);


### PR DESCRIPTION
     Omit ppre1_bit selection value [1 => 0b011] and
     modify default value to "0b100",
     because when ppre_bit value is 0b011,
     ppre1 = 1 << ( 0b011-0b011) = 1,
     pclk1 = hclk / ppre1,
     pclk1 = hclk,
     if hclk is over 32MHz with PLL,
     pclk1 would be over its limit value: 32MHz.