### PR TITLE
Clear serial error flags after reading them

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -181,12 +181,16 @@ macro_rules! hal {
                     let isr = unsafe { (*$USARTX::ptr()).isr.read() };
 
                     Err(if isr.pe().bit_is_set() {
+                        unsafe { (*$USARTX::ptr()).icr.modify(|_r, w| w.pecf().set_bit()) };
                         nb::Error::Other(Error::Parity)
                     } else if isr.fe().bit_is_set() {
+                        unsafe { (*$USARTX::ptr()).icr.modify(|_r, w| w.fecf().set_bit()) };
                         nb::Error::Other(Error::Framing)
                     } else if isr.nf().bit_is_set() {
+                        unsafe { (*$USARTX::ptr()).icr.modify(|_r, w| w.ncf().set_bit()) };
                         nb::Error::Other(Error::Noise)
                     } else if isr.ore().bit_is_set() {
+                        unsafe { (*$USARTX::ptr()).icr.modify(|_r, w| w.orecf().set_bit()) };
                         nb::Error::Other(Error::Overrun)
                     } else if isr.rxne().bit_is_set() {
                         // NOTE(read_volatile) see `write_volatile` below


### PR DESCRIPTION
The current implementaion does not clear the error bits in the ISR register when running `Rx.read()`. This means that after an error has occured, all future reads will return the same error. The bits can be reset by writing to the `ICR` register which is what this patch does.

I'm a bit sceptical of the `unsafe` blocks, but they seem required as the `Rx` struct only contains a pointer to the USARTx registers.

I can also see this being implemented as a separate `clear` function which resets all error flags independently of `read` but I believe that would require modifying the `embedded-hal` crate, right?