### PR TITLE
Implement InputPin trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ version = "0.2.2"
 
 [features]
 rt = ["stm32f30x/rt"]
+unproven = ["embedded-hal/unproven"]

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -95,6 +95,8 @@ macro_rules! gpio {
             use core::marker::PhantomData;
 
             use hal::digital::OutputPin;
+            #[cfg(feature = "unproven")]
+            use hal::digital::InputPin;
             use stm32f30x::{$gpioy, $GPIOX};
 
             use rcc::AHB;
@@ -212,6 +214,18 @@ macro_rules! gpio {
                 fn set_low(&mut self) {
                     // NOTE(unsafe) atomic write to a stateless register
                     unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << (16 + self.i))) }
+                }
+            }
+
+            #[cfg(feature = "unproven")]
+            impl<MODE> InputPin for $PXx<Input<MODE>> {
+                fn is_high(&self) -> bool {
+                    !self.is_low()
+                }
+
+                fn is_low(&self) -> bool {
+                    // NOTE(unsafe) atomic read with no side effects
+                    unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << self.i) == 0 }
                 }
             }
 
@@ -453,6 +467,19 @@ macro_rules! gpio {
                     }
                 }
 
+                impl<MODE> $PXi<Input<MODE>> {
+                    /// Erases the pin number from the type
+                    ///
+                    /// This is useful when you want to collect the pins into an array where you
+                    /// need all the elements to have the same type
+                    pub fn downgrade(self) -> $PXx<Input<MODE>> {
+                        $PXx {
+                            i: $i,
+                            _mode: self._mode,
+                        }
+                    }
+                }
+
                 impl<MODE> OutputPin for $PXi<Output<MODE>> {
                     fn set_high(&mut self) {
                         // NOTE(unsafe) atomic write to a stateless register
@@ -462,6 +489,18 @@ macro_rules! gpio {
                     fn set_low(&mut self) {
                         // NOTE(unsafe) atomic write to a stateless register
                         unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << (16 + $i))) }
+                    }
+                }
+
+                #[cfg(feature = "unproven")]
+                impl<MODE> InputPin for $PXi<Input<MODE>> {
+                    fn is_high(&self) -> bool {
+                        !self.is_low()
+                    }
+
+                    fn is_low(&self) -> bool {
+                        // NOTE(unsafe) atomic read with no side effects
+                        unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << $i) == 0 }
                     }
                 }
             )+


### PR DESCRIPTION
(Ref japaric/embedded-hal#41)

This implements the unproven InputPin trait of embedded-hal.