### PR TITLE
Implements embedded_hal::InputPin for GPIOs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ version = "0.2.2"
 
 [features]
 rt = ["stm32f30x/rt"]
+unproven = ["embedded-hal/unproven"]


### PR DESCRIPTION
Behind an "unproven" feature that is tied to embedded-hal/unproven