### PR TITLE
Enable GPIOs that default as JTAG pins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - rustup self update
 
 install:
-  - sh ci/install.sh
+  - bash ci/install.sh
   - source ~/.cargo/env || true
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,27 @@ matrix:
   include:
     # Linux
     - env: TARGET=x86_64-unknown-linux-gnu
-      rust: nightly
 
     # Bare metal
     - env: TARGET=thumbv7em-none-eabi
-      rust: nightly
+      rust: beta
+      addons:
+        apt:
+          packages:
+            - gcc-arm-none-eabi
+
     - env: TARGET=thumbv7em-none-eabihf
-      rust: nightly
+      rust: beta
+      addons:
+        apt:
+          packages:
+            - gcc-arm-none-eabi
 
 before_install:
   - set -e
-  - rustup self update
 
 install:
   - bash ci/install.sh
-  - source ~/.cargo/env || true
 
 script:
   - bash ci/script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
-# Based on the "trust" template v0.1.2
-# https://github.com/japaric/trust/tree/v0.1.2
-
 language: rust
-services: docker
 
 matrix:
   include:
@@ -29,10 +25,7 @@ script:
 
 after_script: set +e
 
-cache:
-  cargo: true
-  directories:
-    - $HOME/.xargo
+cache: cargo
 
 before_cache:
   # Travis can't cache files that are not readable by "others"
@@ -40,9 +33,8 @@ before_cache:
 
 branches:
   only:
-    - auto
-    - master
-    - try
+    - staging
+    - trying
 
 notifications:
   email:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.2.0] - 2018-05-12
+
+- This crate now compiles on the stable and beta channels.
+
+- [breaking-change] implement v0.2.0 of `embedded-hal`
+
+- [breaking-change] this crate now requires `arm-none-eabi-gcc` to be installed and available in
+  `$PATH` to compile.
+
 ## [v0.1.2] - 2018-02-09
 
 ### Fixed
@@ -23,5 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/japaric/stm32f30x-hal/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/japaric/stm32f30x-hal/compare/v0.2.0...HEAD
+[v0.2.0]: https://github.com/japaric/stm32f30x-hal/compare/v0.1.2...v0.2.0
+[v0.1.2]: https://github.com/japaric/stm32f30x-hal/compare/v0.1.1...v0.1.2
 [v0.1.1]: https://github.com/japaric/stm32f30x-hal/compare/v0.1.0...v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,17 @@ keywords = ["arm", "cortex-m", "stm32", "hal"]
 license = "MIT OR Apache-2.0"
 name = "stm32f30x-hal"
 repository = "https://github.com/japaric/stm32f30x-hal"
-version = "0.1.2"
+version = "0.2.0"
 
 [dependencies]
-cortex-m = "0.4.0"
-embedded-hal = "0.1.0"
+cortex-m = "0.5.0"
+embedded-hal = "0.2.0"
 nb = "0.1.0"
-stm32f30x = "0.6.0"
+stm32f30x = "0.7.0"
+
+[dependencies.void]
+default-features = false
+version = "1.0.2"
 
 [dependencies.cast]
 default-features = false

--- a/Xargo.toml
+++ b/Xargo.toml
@@ -1,6 +1,0 @@
-[dependencies.core]
-stage = 0
-
-[dependencies.compiler_builtins]
-features = ["mem"]
-stage = 1

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,3 @@
+status = [
+  "continuous-integration/travis-ci/push",
+]

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,21 +1,9 @@
-set -ex
+set -euxo pipefail
 
 main() {
-    # This fetches latest stable release of Xargo
-    local tag=$(git ls-remote --tags --refs --exit-code https://github.com/japaric/xargo \
-                       | cut -d/ -f3 \
-                       | grep -E '^v[0.1.0-9.]+$' \
-                       | sort --version-sort \
-                       | tail -n1)
-
-    curl -LSfs https://japaric.github.io/trust/install.sh | \
-        sh -s -- \
-           --force \
-           --git japaric/xargo \
-           --tag $tag \
-           --target x86_64-unknown-linux-musl
-
-    rustup component add rust-src
+    if [ $TARGET != x86_64-unknown-linux-gnu ]; then
+        rustup target add $TARGET
+    fi
 }
 
 main

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -2,10 +2,7 @@ set -euxo pipefail
 
 main() {
     cargo check --target $TARGET
-
-    if [ $TARGET != x86_64-unknown-linux-gnu ]; then
-        cargo check --target $TARGET --features rt
-    fi
+    cargo check --target $TARGET --features rt
 }
 
 main

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,21 +1,11 @@
-# This script takes care of testing your crate
-
-set -ex
+set -euxo pipefail
 
 main() {
-    case $TARGET in
-        x86_64-unknown-linux-gnu)
-            cargo check --target $TARGET
-            ;;
-        *)
-            xargo check --target $TARGET
-            xargo check --target $TARGET --features rt
-            ;;
-    esac
+    cargo check --target $TARGET
 
+    if [ $TARGET != x86_64-unknown-linux-gnu ]; then
+        cargo check --target $TARGET --features rt
+    fi
 }
 
-# we don't run the "test phase" when doing deploys
-if [ -z $TRAVIS_TAG ]; then
-    main
-fi
+main

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,8 +1,8 @@
 //! Delays
 
 use cast::u32;
-use cortex_m::peripheral::SYST;
 use cortex_m::peripheral::syst::SystClkSource;
+use cortex_m::peripheral::SYST;
 
 use hal::blocking::delay::{DelayMs, DelayUs};
 use rcc::Clocks;

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -204,15 +204,6 @@ macro_rules! gpio {
             }
 
             impl<MODE> OutputPin for $PXx<Output<MODE>> {
-                fn is_high(&self) -> bool {
-                    !self.is_low()
-                }
-
-                fn is_low(&self) -> bool {
-                    // NOTE(unsafe) atomic read with no side effects
-                    unsafe { (*$GPIOX::ptr()).odr.read().bits() & (1 << self.i) == 0 }
-                }
-
                 fn set_high(&mut self) {
                     // NOTE(unsafe) atomic write to a stateless register
                     unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << self.i)) }
@@ -463,15 +454,6 @@ macro_rules! gpio {
                 }
 
                 impl<MODE> OutputPin for $PXi<Output<MODE>> {
-                    fn is_high(&self) -> bool {
-                        !self.is_low()
-                    }
-
-                    fn is_low(&self) -> bool {
-                        // NOTE(unsafe) atomic read with no side effects
-                        unsafe { (*$GPIOX::ptr()).odr.read().bits() & (1 << $i) == 0 }
-                    }
-
                     fn set_high(&mut self) {
                         // NOTE(unsafe) atomic write to a stateless register
                         unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << $i)) }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -483,19 +483,17 @@ gpio!(GPIOA, gpioa, gpioa, iopaen, ioparst, PAx, [
     PA10: (pa10, 10, Input<Floating>, AFRH),
     PA11: (pa11, 11, Input<Floating>, AFRH),
     PA12: (pa12, 12, Input<Floating>, AFRH),
-    // TODO these are configured as JTAG pins
-    // PA13: (13, Input<Floating>),
-    // PA14: (14, Input<Floating>),
-    // PA15: (15, Input<Floating>),
+    PA13: (pa13, 13, Input<Floating>, AFRH),
+    PA14: (pa14, 14, Input<Floating>, AFRH),
+    PA15: (pa15, 15, Input<Floating>, AFRH),
 ]);
 
 gpio!(GPIOB, gpiob, gpiob, iopben, iopbrst, PBx, [
     PB0: (pb0, 0, Input<Floating>, AFRL),
     PB1: (pb1, 1, Input<Floating>, AFRL),
     PB2: (pb2, 2, Input<Floating>, AFRL),
-    // TODO these are configured as JTAG pins
-    // PB3: (3, Input<Floating>),
-    // PB4: (4, Input<Floating>),
+    PB3: (pb3, 3, Input<Floating>, AFRL),
+    PB4: (pb4, 4, Input<Floating>, AFRL),
     PB5: (pb5, 5, Input<Floating>, AFRL),
     PB6: (pb6, 6, Input<Floating>, AFRL),
     PB7: (pb7, 7, Input<Floating>, AFRL),

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -483,17 +483,17 @@ gpio!(GPIOA, gpioa, gpioa, iopaen, ioparst, PAx, [
     PA10: (pa10, 10, Input<Floating>, AFRH),
     PA11: (pa11, 11, Input<Floating>, AFRH),
     PA12: (pa12, 12, Input<Floating>, AFRH),
-    PA13: (pa13, 13, Input<Floating>, AFRH),
-    PA14: (pa14, 14, Input<Floating>, AFRH),
-    PA15: (pa15, 15, Input<Floating>, AFRH),
+    PA13: (pa13, 13, Input<PullUp>, AFRH),
+    PA14: (pa14, 14, Input<PullDown>, AFRH),
+    PA15: (pa15, 15, Input<PullUp>, AFRH),
 ]);
 
 gpio!(GPIOB, gpiob, gpiob, iopben, iopbrst, PBx, [
     PB0: (pb0, 0, Input<Floating>, AFRL),
     PB1: (pb1, 1, Input<Floating>, AFRL),
     PB2: (pb2, 2, Input<Floating>, AFRL),
-    PB3: (pb3, 3, Input<Floating>, AFRL),
-    PB4: (pb4, 4, Input<Floating>, AFRL),
+    PB3: (pb3, 3, Output<Floating>, AFRL),
+    PB4: (pb4, 4, Input<PullUp>, AFRL),
     PB5: (pb5, 5, Input<Floating>, AFRL),
     PB6: (pb6, 6, Input<Floating>, AFRL),
     PB7: (pb7, 7, Input<Floating>, AFRL),

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -22,7 +22,8 @@ pub enum Error {
     // Pec, // SMBUS mode only
     // Timeout, // SMBUS mode only
     // Alert, // SMBUS mode only
-    #[doc(hidden)] _Extensible,
+    #[doc(hidden)]
+    _Extensible,
 }
 
 // FIXME these should be "closed" traits
@@ -68,7 +69,7 @@ macro_rules! busy_wait {
                 // try again
             }
         }
-    }
+    };
 }
 
 macro_rules! hal {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,23 +5,26 @@
 //!
 //! [`embedded-hal`]: https://github.com/japaric/embedded-hal
 //!
+//! # Requirements
+//!
+//! This crate requires `arm-none-eabi-gcc` to be installed and available in `$PATH` to build.
+//!
 //! # Usage
 //!
 //! To build applications (binary crates) using this crate follow the [cortex-m-quickstart]
 //! instructions and add this crate as a dependency in step number 5 and make sure you enable the
 //! "rt" Cargo feature of this crate.
 //!
-//! [cortex-m-quickstart]: https://docs.rs/cortex-m-quickstart/~0.2.3
+//! [cortex-m-quickstart]: https://docs.rs/cortex-m-quickstart/~0.3
 //!
 //! # Examples
 //!
 //! Examples of *using* these abstractions can be found in the documentation of the [`f3`] crate.
 //!
-//! [`f3`]: https://docs.rs/f3/~0.5.1
+//! [`f3`]: https://docs.rs/f3/~0.6
 
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![feature(never_type)]
 #![no_std]
 
 extern crate cast;
@@ -29,6 +32,7 @@ extern crate cortex_m;
 extern crate embedded_hal as hal;
 extern crate nb;
 pub extern crate stm32f30x;
+extern crate void;
 
 pub mod delay;
 pub mod flash;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,7 @@
 //! Prelude
 
+pub use flash::FlashExt as _stm32f30x_hal_flash_FlashExt;
 pub use gpio::GpioExt as _stm32f30x_hal_gpio_GpioExt;
 pub use hal::prelude::*;
 pub use rcc::RccExt as _stm32f30x_hal_rcc_RccExt;
 pub use time::U32Ext as _stm32f30x_hal_time_U32Ext;
-pub use flash::FlashExt as _stm32f30x_hal_flash_FlashExt;

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -276,7 +276,8 @@ pub struct Clocks {
     pclk2: Hertz,
     ppre1: u8,
     // TODO remove `allow`
-    #[allow(dead_code)] ppre2: u8,
+    #[allow(dead_code)]
+    ppre2: u8,
     sysclk: Hertz,
 }
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,11 +1,12 @@
 //! Serial
 
-use core::ptr;
 use core::marker::PhantomData;
+use core::ptr;
 
 use hal::serial;
 use nb;
 use stm32f30x::{USART1, USART2, USART3};
+use void::Void;
 
 use gpio::gpioa::{PA10, PA2, PA3, PA9};
 use gpio::gpiob::{PB10, PB11, PB6, PB7};
@@ -35,7 +36,8 @@ pub enum Error {
     Overrun,
     /// Parity check error
     Parity,
-    #[doc(hidden)] _Extensible,
+    #[doc(hidden)]
+    _Extensible,
 }
 
 // FIXME these should be "closed" traits
@@ -200,12 +202,13 @@ macro_rules! hal {
             }
 
             impl serial::Write<u8> for Tx<$USARTX> {
-                // NOTE(!) See section "29.7 USART interrupts"; the only possible errors during transmission
-                // are: clear to send (which is disabled in this case) errors and framing errors (which only
-                // occur in SmartCard mode); neither of these apply to our hardware configuration
-                type Error = !;
+                // NOTE(Void) See section "29.7 USART interrupts"; the only possible errors during
+                // transmission are: clear to send (which is disabled in this case) errors and
+                // framing errors (which only occur in SmartCard mode); neither of these apply to
+                // our hardware configuration
+                type Error = Void;
 
-                fn flush(&mut self) -> nb::Result<(), !> {
+                fn flush(&mut self) -> nb::Result<(), Void> {
                     // NOTE(unsafe) atomic read with no side effects
                     let isr = unsafe { (*$USARTX::ptr()).isr.read() };
 
@@ -216,7 +219,7 @@ macro_rules! hal {
                     }
                 }
 
-                fn write(&mut self, byte: u8) -> nb::Result<(), !> {
+                fn write(&mut self, byte: u8) -> nb::Result<(), Void> {
                     // NOTE(unsafe) atomic read with no side effects
                     let isr = unsafe { (*$USARTX::ptr()).isr.read() };
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -22,7 +22,8 @@ pub enum Error {
     ModeFault,
     /// CRC error
     Crc,
-    #[doc(hidden)] _Extensible,
+    #[doc(hidden)]
+    _Extensible,
 }
 
 // FIXME these should be "closed" traits

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -4,6 +4,7 @@ use cast::{u16, u32};
 use hal::timer::{CountDown, Periodic};
 use nb;
 use stm32f30x::{TIM2, TIM3, TIM4, TIM6, TIM7};
+use void::Void;
 
 use rcc::{APB1, Clocks};
 use time::Hertz;
@@ -57,7 +58,7 @@ macro_rules! hal {
                     self.tim.cr1.modify(|_, w| w.cen().set_bit());
                 }
 
-                fn wait(&mut self) -> nb::Result<(), !> {
+                fn wait(&mut self) -> nb::Result<(), Void> {
                     if self.tim.sr.read().uif().bit_is_clear() {
                         Err(nb::Error::WouldBlock)
                     } else {


### PR DESCRIPTION
These pins default to JTAG functions, but can be released to other
GPIO functions by the application.