### PR TITLE
Implement new hal traits with unproven feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Add an "unproven" Cargo feature that enables the "unproven" feature of the embedded-hal dependency.
+
+- Implement StatefulOutputPin, ToggleableOutputPin, and InputPin traits with "unproven" feature.
+
 ## [v0.2.0] - 2018-05-12
 
 - This crate now compiles on the stable and beta channels.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ version = "0.2.2"
 
 [features]
 rt = ["stm32f30x/rt"]
+unproven = ["embedded-hal/unproven"]

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -95,6 +95,8 @@ macro_rules! gpio {
             use core::marker::PhantomData;
 
             use hal::digital::OutputPin;
+            #[cfg(feature = "unproven")]
+            use hal::digital::{StatefulOutputPin, InputPin, toggleable};
             use stm32f30x::{$gpioy, $GPIOX};
 
             use rcc::AHB;
@@ -212,6 +214,33 @@ macro_rules! gpio {
                 fn set_low(&mut self) {
                     // NOTE(unsafe) atomic write to a stateless register
                     unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << (16 + self.i))) }
+                }
+            }
+
+            #[cfg(feature = "unproven")]
+            impl<MODE> StatefulOutputPin for $PXx<Output<MODE>> {
+                fn is_set_high(&self) -> bool {
+                    !self.is_set_low()
+                }
+
+                fn is_set_low(&self) -> bool {
+                    // NOTE(unsafe) atomic read with no side effects
+                    unsafe { (*$GPIOX::ptr()).odr.read().bits() & (1 << self.i) == 0 }
+                }
+            }
+
+            #[cfg(feature = "unproven")]
+            impl<MODE> toggleable::Default for $PXx<Output<MODE>> {}
+
+            #[cfg(feature = "unproven")]
+            impl<MODE> InputPin for $PXx<Input<MODE>> {
+                fn is_high(&self) -> bool {
+                    !self.is_low()
+                }
+
+                fn is_low(&self) -> bool {
+                    // NOTE(unsafe) atomic read with no side effects
+                    unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << self.i) == 0 }
                 }
             }
 
@@ -453,6 +482,20 @@ macro_rules! gpio {
                     }
                 }
 
+                #[cfg(feature = "unproven")]
+                impl<MODE> $PXi<Input<MODE>> {
+                    /// Erases the pin number from the type
+                    ///
+                    /// This is useful when you want to collect the pins into an array where you
+                    /// need all the elements to have the same type
+                    pub fn downgrade(self) -> $PXx<Input<MODE>> {
+                        $PXx {
+                            i: $i,
+                            _mode: self._mode,
+                        }
+                    }
+                }
+
                 impl<MODE> OutputPin for $PXi<Output<MODE>> {
                     fn set_high(&mut self) {
                         // NOTE(unsafe) atomic write to a stateless register
@@ -462,6 +505,33 @@ macro_rules! gpio {
                     fn set_low(&mut self) {
                         // NOTE(unsafe) atomic write to a stateless register
                         unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << (16 + $i))) }
+                    }
+                }
+
+                #[cfg(feature = "unproven")]
+                impl<MODE> StatefulOutputPin for $PXi<Output<MODE>> {
+                    fn is_set_high(&self) -> bool {
+                        !self.is_set_low()
+                    }
+
+                    fn is_set_low(&self) -> bool {
+                        // NOTE(unsafe) atomic read with no side effects
+                        unsafe { (*$GPIOX::ptr()).odr.read().bits() & (1 << $i) == 0 }
+                    }
+                }
+
+                #[cfg(feature = "unproven")]
+                impl<MODE> toggleable::Default for $PXi<Output<MODE>> {}
+
+                #[cfg(feature = "unproven")]
+                impl<MODE> InputPin for $PXi<Input<MODE>> {
+                    fn is_high(&self) -> bool {
+                        !self.is_low()
+                    }
+
+                    fn is_low(&self) -> bool {
+                        // NOTE(unsafe) atomic read with no side effects
+                        unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << $i) == 0 }
                     }
                 }
             )+


### PR DESCRIPTION
- Add an "unproven" Cargo feature that enables the "unproven" feature of the
  embedded-hal dependency.
- Implement StatefulOutputPin, ToggleableOutputPin, and InputPin traits with
  the "unproven" feature.

Acknowledgements to @octycs who added the InputPin trait first.
Improves on #16