### PR TITLE
Implement Read for i2c peripherals

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -7,7 +7,7 @@ use gpio::gpioa::{PA10, PA9};
 use gpio::gpiob::{PB6, PB7, PB8, PB9};
 use gpio::gpiof::{PF0, PF1, PF6};
 use gpio::AF4;
-use hal::blocking::i2c::{Write, WriteRead};
+use hal::blocking::i2c::{Write, WriteRead, Read};
 use rcc::{APB1, Clocks};
 use time::Hertz;
 
@@ -260,6 +260,47 @@ macro_rules! hal {
                     busy_wait!(self.i2c, tc);
 
                     // reSTART and prepare to receive bytes into `buffer`
+                    self.i2c.cr2.write(|w| {
+                        w.sadd1()
+                            .bits(addr)
+                            .rd_wrn()
+                            .set_bit()
+                            .nbytes()
+                            .bits(buffer.len() as u8)
+                            .start()
+                            .set_bit()
+                            .autoend()
+                            .set_bit()
+                    });
+
+                    for byte in buffer {
+                        // Wait until we have received something
+                        busy_wait!(self.i2c, rxne);
+
+                        *byte = self.i2c.rxdr.read().rxdata().bits();
+                    }
+
+                    // automatic STOP
+
+                    Ok(())
+                }
+            }
+
+            impl <PINS> Read for I2c<$I2CX, PINS> {
+                type Error = Error;
+
+                fn read(
+                    &mut self,
+                    addr: u8,
+                    buffer: &mut [u8],
+                ) -> Result<(), Error> {
+                    // TODO support transfers of more than 255 bytes
+                    assert!(buffer.len() < 256 && buffer.len() > 0);
+
+                    // TODO do we have to explicitly wait here if the bus is busy (e.g. another
+                    // master is communicating)?
+
+                    // START and prepare to receive bytes into `buffer`
                     self.i2c.cr2.write(|w| {
                         w.sadd1()
                             .bits(addr)


### PR DESCRIPTION
Implement [`embedded_hal::blocking::i2c::Read`](https://docs.rs/embedded-hal/0.2.1/embedded_hal/blocking/i2c/trait.Read.html) for i2c peripherals