### PR TITLE
Add deprecation notice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "stm32f30x-hal"
 repository = "https://github.com/japaric/stm32f30x-hal"
 version = "0.2.0"
+maintenance = { status = "deprecated" }
 
 [dependencies]
 cortex-m = "0.5.0"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 [`embedded-hal`]: https://crates.io/crates/embedded-hal
 
+***DEPRECATED:***  
+This crate is no longer actively maintained.  
+Use the [stm32f3xx-hal](https://github.com/stm32-rs/stm32f3xx-hal) crate instead.
+
 ## [Documentation](https://docs.rs/stm32f30x-hal)
 
 ## License


### PR DESCRIPTION
Points users to the actively maintained stm32f3xx-hal crate.
Related issues:
 - https://github.com/japaric/stm32f30x-hal/issues/36
 - https://github.com/stm32-rs/stm32f3xx-hal/issues/48